### PR TITLE
Allow filtering of group and host list

### DIFF
--- a/ansible-tty
+++ b/ansible-tty
@@ -163,7 +163,19 @@ def choose_group(inventory: Dict[str, Any], current_level: Optional[str] = None)
 
         print(table)
 
-        user_input = input("Choose a valid group index, filter with '/keyword' or press CTRL+C to exit: ").strip()
+        prompt = "Choose a valid group index, filter with '/keyword'"
+        if len(current_list) == 1:
+            prompt += " or press Enter to select the only option"
+        prompt += " or press CTRL+C to exit: "
+
+        user_input = input(prompt).strip()
+
+        if not user_input and len(current_list) == 1:
+            selected_group = current_list[0]
+            if "children" in inventory.get(selected_group, {}):
+                return choose_group(inventory, selected_group)
+            else:
+                return selected_group
 
         if user_input == '/':
             current_list = sorted_groups
@@ -238,7 +250,15 @@ def choose_host(inventory: Dict[str, Any], group_name: str) -> str:
 
         print(table)
 
-        user_input = input(f"Choose a valid host index, filter with '/keyword' or press CTRL+C to exit: ").strip()
+        prompt = f"Choose a valid host index, filter with '/keyword'"
+        if len(current_rows) == 1:
+            prompt += " or press Enter to select the only option"
+        prompt += f" or press CTRL+C to exit: "
+
+        user_input = input(prompt).strip()
+
+        if not user_input and len(current_rows) == 1:
+            return current_rows[0]["host"]
 
         if user_input == '/':
             current_rows = rows_data

--- a/ansible-tty
+++ b/ansible-tty
@@ -151,6 +151,7 @@ def choose_group(inventory: Dict[str, Any], current_level: Optional[str] = None)
     current_list = sorted_groups
 
     while True:
+        os.system('clear')
         print(f"Choose a group{' (filtered)' if len(current_list) < len(sorted_groups) else ''}:")
         table = PrettyTable()
         table.field_names = ["Index", "Group Name"]
@@ -220,6 +221,7 @@ def choose_host(inventory: Dict[str, Any], group_name: str) -> str:
     current_rows = rows_data
 
     while True:
+        os.system('clear')
         print(f"Choose a host from group {group_name}{' (filtered)' if len(current_rows) < len(rows_data) else ''}:")
         table = PrettyTable()
         table.field_names = [

--- a/ansible-tty
+++ b/ansible-tty
@@ -164,6 +164,10 @@ def choose_group(inventory: Dict[str, Any], current_level: Optional[str] = None)
 
         user_input = input("Choose a valid group index, filter with '/keyword' or press CTRL+C to exit: ").strip()
 
+        if user_input == '/':
+            current_list = sorted_groups
+            continue
+
         if user_input.startswith('/'):
             filter_str = user_input[1:].lower()
             new_list = [g for g in sorted_groups if filter_str in g.lower() or filter_str in shorten_group_name(g).lower()]
@@ -233,6 +237,10 @@ def choose_host(inventory: Dict[str, Any], group_name: str) -> str:
         print(table)
 
         user_input = input(f"Choose a valid host index, filter with '/keyword' or press CTRL+C to exit: ").strip()
+
+        if user_input == '/':
+            current_rows = rows_data
+            continue
 
         if user_input.startswith('/'):
             filter_str = user_input[1:].lower()

--- a/ansible-tty
+++ b/ansible-tty
@@ -151,7 +151,7 @@ def choose_group(inventory: Dict[str, Any], current_level: Optional[str] = None)
     current_list = sorted_groups
 
     while True:
-        os.system('clear')
+        print("\033[H\033[J", end="")
         print(f"Choose a group{' (filtered)' if len(current_list) < len(sorted_groups) else ''}:")
         table = PrettyTable()
         table.field_names = ["Index", "Group Name"]
@@ -221,7 +221,7 @@ def choose_host(inventory: Dict[str, Any], group_name: str) -> str:
     current_rows = rows_data
 
     while True:
-        os.system('clear')
+        print("\033[H\033[J", end="")
         print(f"Choose a host from group {group_name}{' (filtered)' if len(current_rows) < len(rows_data) else ''}:")
         table = PrettyTable()
         table.field_names = [

--- a/ansible-tty
+++ b/ansible-tty
@@ -147,24 +147,31 @@ def choose_group(inventory: Dict[str, Any], current_level: Optional[str] = None)
         # If no current level is provided, list the top-level groups
         groups = get_top_level_groups(inventory)
 
-
-    print("Choose a group:")
-    table = PrettyTable()
-    table.field_names = ["Index", "Group Name"]
-    table.align = "l"
-    table.border = True
-
     sorted_groups = sorted(groups)
-    display_names = [shorten_group_name(group) for group in sorted_groups]
-    for index, group in enumerate(display_names):
-        table.add_row([index, group])
-
-    print(table)
+    current_list = sorted_groups
 
     while True:
+        print(f"Choose a group{' (filtered)' if len(current_list) < len(sorted_groups) else ''}:")
+        table = PrettyTable()
+        table.field_names = ["Index", "Group Name"]
+        table.align = "l"
+        table.border = True
+
+        for index, group in enumerate(current_list):
+            table.add_row([index, shorten_group_name(group)])
+
+        print(table)
+
+        user_input = input("Choose a valid group index, filter with '/keyword' or press CTRL+C to exit: ").strip()
+
+        if user_input.startswith('/'):
+            filter_str = user_input[1:].lower()
+            current_list = [g for g in sorted_groups if filter_str in g.lower() or filter_str in shorten_group_name(g).lower()]
+            continue
+
         try:
-            option = int(input("Choose a valid group index or press CTRL+C to exit: "))
-            selected_group = sorted_groups[option]
+            option = int(user_input)
+            selected_group = current_list[option]
 
             # If selected group has children, go one tier deeper, else return the group
             if "children" in inventory.get(selected_group, {}):
@@ -177,72 +184,63 @@ def choose_group(inventory: Dict[str, Any], current_level: Optional[str] = None)
             
 def choose_host(inventory: Dict[str, Any], group_name: str) -> str:
     """Allow the user to choose a host from a specific group in the inventory."""
-    hosts = inventory[group_name]["hosts"]
+    hosts = sorted(inventory[group_name]["hosts"])
     all_hostvars = inventory["_meta"]["hostvars"]
 
-    print(f"Choose a host from group {group_name}:")
-    table = PrettyTable()
-    # Add the 'Ansible User', 'Cloud Provider', 'Environment', and 'Connection' columns
-    table.field_names = [
-        "Index",
-        "Host",
-        "Target",
-        "User",
-        "Cloud Provider",
-        "Environment",
-        "Connection",
-        "VPN",
-        "Owner",
-        "Comments",
-    ]
-    table.align = "l"
-    table.border = True
-
-    for index, host in enumerate(sorted(hosts)):
+    # Pre-calculate row data for faster filtering and display
+    rows_data = []
+    for host in hosts:
         hostvars = all_hostvars.get(host, {})
         connection_protocol = hostvars.get("connection_protocol", "ssh").upper()
-
-        # For SSM, show instance_id or instance_name, for SSH show ansible_host
         if connection_protocol == "SSM":
             target = hostvars.get("instance_id") or hostvars.get("instance_name", "N/A")
         else:
             target = hostvars.get("ansible_host", "N/A")
 
-        ansible_user = hostvars.get(
-            "ansible_user", "N/A"
-        )  # Default to "N/A" if not specified
-        # Fetch cloud provider and environment or set to "N/A" if not present
-        cloud_provider = hostvars.get("cloud_provider", "N/A")
-        environment = hostvars.get("environment", "N/A")
-        vpn = hostvars.get("vpn", "N/A")
-        owner = hostvars.get("owner", "N/A")
-        comments = hostvars.get("comments", "N/A")
-        table.add_row(
-            [
-                index,
-                host,
-                target,
-                ansible_user,
-                cloud_provider,
-                environment,
-                connection_protocol,
-                vpn,
-                owner,
-                comments,
-            ]
-        )
+        rows_data.append({
+            "host": host,
+            "target": target,
+            "user": hostvars.get("ansible_user", "N/A"),
+            "cloud": hostvars.get("cloud_provider", "N/A"),
+            "env": hostvars.get("environment", "N/A"),
+            "conn": connection_protocol,
+            "vpn": hostvars.get("vpn", "N/A"),
+            "owner": hostvars.get("owner", "N/A"),
+            "comments": hostvars.get("comments", "N/A"),
+        })
 
-    print(table)
+    current_rows = rows_data
 
     while True:
+        print(f"Choose a host from group {group_name}{' (filtered)' if len(current_rows) < len(rows_data) else ''}:")
+        table = PrettyTable()
+        table.field_names = [
+            "Index", "Host", "Target", "User", "Cloud Provider", "Environment", "Connection", "VPN", "Owner", "Comments",
+        ]
+        table.align = "l"
+        table.border = True
+
+        for index, row in enumerate(current_rows):
+            table.add_row([
+                index, row["host"], row["target"], row["user"], row["cloud"],
+                row["env"], row["conn"], row["vpn"], row["owner"], row["comments"]
+            ])
+
+        print(table)
+
+        user_input = input(f"Choose a valid host index, filter with '/keyword' or press CTRL+C to exit: ").strip()
+
+        if user_input.startswith('/'):
+            filter_str = user_input[1:].lower()
+            current_rows = [
+                row for row in rows_data
+                if any(filter_str in str(val).lower() for val in row.values())
+            ]
+            continue
+
         try:
-            option = int(
-                input(
-                    f"Choose a valid host index from group {group_name} or press CTRL+C to exit: "
-                )
-            )
-            selected_host = sorted(hosts)[option]
-            return selected_host
+            option = int(user_input)
+            return current_rows[option]["host"]
         except (ValueError, IndexError):
             logger.warning("Please enter a valid index.")
 

--- a/ansible-tty
+++ b/ansible-tty
@@ -469,4 +469,8 @@ def main() -> None:
     os.execvp('bash', ['bash', '-c', ' '.join(connection_cmd)])
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\n\nOperation cancelled by user. Exiting...")
+        sys.exit(0)

--- a/ansible-tty
+++ b/ansible-tty
@@ -166,7 +166,11 @@ def choose_group(inventory: Dict[str, Any], current_level: Optional[str] = None)
 
         if user_input.startswith('/'):
             filter_str = user_input[1:].lower()
-            current_list = [g for g in sorted_groups if filter_str in g.lower() or filter_str in shorten_group_name(g).lower()]
+            new_list = [g for g in sorted_groups if filter_str in g.lower() or filter_str in shorten_group_name(g).lower()]
+            if not new_list:
+                print(f"\033[91mNo groups found matching '{filter_str}'. Keeping current list.\033[0m")
+            else:
+                current_list = new_list
             continue
 
         try:
@@ -232,10 +236,14 @@ def choose_host(inventory: Dict[str, Any], group_name: str) -> str:
 
         if user_input.startswith('/'):
             filter_str = user_input[1:].lower()
-            current_rows = [
+            new_rows = [
                 row for row in rows_data
                 if any(filter_str in str(val).lower() for val in row.values())
             ]
+            if not new_rows:
+                print(f"\033[91mNo hosts found matching '{filter_str}'. Keeping current list.\033[0m")
+            else:
+                current_rows = new_rows
             continue
 
         try:


### PR DESCRIPTION
When the list of optios is large (currently at 40) takes time to find the required option, this PR allows to filter the group and host options to find the group/host more quickly.

Features Added:

   - Filtering: Type /keyword to filter the table (case-insensitive, multiple fields).
   - Auto-selection: If only one option remains, just press Enter to select it.
   - Visual Feedback: The table header shows (filtered) and the prompt dynamically updates to offer the "Enter" option.
   - Error Handling: Red error message if no results found, keeping the previous list.
   - Reset: Type / to clear the filter.
   - Smooth Screen Clearing: Clear the screen on each selection to reduce clutter.
   - Clean Exit: Handled Ctrl+C for a graceful termination.
